### PR TITLE
Align logo-image with title in site header

### DIFF
--- a/src/components/common/navigation/style.js
+++ b/src/components/common/navigation/style.js
@@ -76,10 +76,11 @@ export const Brand = styled.div`
     list-style: none;
     margin: 0;
     padding: 0;
-
+    display: flex;
     a {
       color: ${props => props.theme.color.black.regular};
       text-decoration: none;
+      margin-left: 7px;
     }
   }
 `


### PR DESCRIPTION
# Description

Minor style changes to align the logo image with the site title


## Related Issues
Fixes https://github.com/M0nica/ambition-fund-website/issues/5
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

## Pages/Interfaces that will change

Home page

### Screenshots of Changes

#### Before: 
<img width="260" alt="Screen Shot 2020-06-21 at 9 34 50 AM" src="https://user-images.githubusercontent.com/42680433/85230072-7b202700-b3a2-11ea-9451-0b29972c3336.png">


#### After: 
<img width="260" alt="Screen Shot 2020-06-21 at 7 46 14 AM" src="https://user-images.githubusercontent.com/42680433/85230021-33010480-b3a2-11ea-9e0d-f4b27a19dceb.png">

## Steps to test
<!-- What steps should someone walk through to test this improvement? -->
1. Go to http://localhost:8000/ and make sure the brand-image is aligned with the site title