### PR TITLE
Fix: Add opportunities link to nav and make links more flexible

### DIFF
--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react"
+import { Link } from "gatsby"
 import AnchorLink from "react-anchor-link-smooth-scroll"
 import Scrollspy from "react-scrollspy"
 import { Menu, X } from "react-feather"
@@ -64,6 +65,9 @@ export default class Navigation extends Component {
         {NAV_ITEMS.map(navItem => (
           <NavItem key={navItem}>{this.getNavAnchorLink(navItem)}</NavItem>
         ))}
+        <Link to="/opportunities" onClick={this.closeMobileMenu}>
+          Opportunities
+        </Link>
       </Scrollspy>
     </NavListWrapper>
   )

--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -16,7 +16,10 @@ import {
   Mobile,
 } from "./style"
 
-const NAV_ITEMS = ["Mission"]
+const NAV_ITEMS = [
+  { name: "Mission", pathname: "/", hash: "#mission" },
+  { name: "Opportunities", pathname: "/opportunities" },
+]
 
 export default class Navigation extends Component {
   state = {
@@ -48,28 +51,27 @@ export default class Navigation extends Component {
     }
   }
 
-  getNavAnchorLink = item => (
-    <AnchorLink href={`#${item.toLowerCase()}`} onClick={this.closeMobileMenu}>
-      {item}
-    </AnchorLink>
-  )
+  getNavLink = ({ name, pathname, hash }) => {
+    return window.location.pathname === pathname && hash ? (
+      <AnchorLink href={hash}>{name}</AnchorLink>
+    ) : (
+      <Link to={`${hash ? pathname + hash : pathname}`}>{name}</Link>
+    )
+  }
 
   getNavList = ({ mobile = false }) => (
     <NavListWrapper mobile={mobile}>
       <Scrollspy
-        items={NAV_ITEMS.map(item => item.toLowerCase())}
+        items={NAV_ITEMS.map(item => item.name.toLowerCase())}
         currentClassName="active"
         mobile={mobile}
         offset={-64}
       >
         {NAV_ITEMS.map(navItem => (
-          <NavItem key={navItem}>{this.getNavAnchorLink(navItem)}</NavItem>
+          <NavItem key={navItem.name} onClick={this.closeMobileMenu}>
+            {this.getNavLink(navItem)}
+          </NavItem>
         ))}
-        <NavItem>
-          <Link to="/opportunities" onClick={this.closeMobileMenu}>
-            Opportunities
-          </Link>
-        </NavItem>
       </Scrollspy>
     </NavListWrapper>
   )
@@ -83,9 +85,11 @@ export default class Navigation extends Component {
           <Brand>
             <Scrollspy offset={-64} item={["top"]} currentClassName="active">
               <Image />
-              <AnchorLink href="#top" onClick={this.closeMobileMenu}>
-                Ambition Fund
-              </AnchorLink>
+              {this.getNavLink({
+                name: "Ambition Fund",
+                pathname: "/",
+                hash: "#top",
+              })}
             </Scrollspy>
           </Brand>
           <Mobile>

--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -65,9 +65,11 @@ export default class Navigation extends Component {
         {NAV_ITEMS.map(navItem => (
           <NavItem key={navItem}>{this.getNavAnchorLink(navItem)}</NavItem>
         ))}
-        <Link to="/opportunities" onClick={this.closeMobileMenu}>
-          Opportunities
-        </Link>
+        <NavItem>
+          <Link to="/opportunities" onClick={this.closeMobileMenu}>
+            Opportunities
+          </Link>
+        </NavItem>
       </Scrollspy>
     </NavListWrapper>
   )

--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -53,9 +53,16 @@ export default class Navigation extends Component {
 
   getNavLink = ({ name, pathname, hash }) => {
     return window.location.pathname === pathname && hash ? (
-      <AnchorLink href={hash}>{name}</AnchorLink>
+      <AnchorLink href={hash} onClick={this.closeMobileMenu}>
+        {name}
+      </AnchorLink>
     ) : (
-      <Link to={`${hash ? pathname + hash : pathname}`}>{name}</Link>
+      <Link
+        to={`${hash ? pathname + hash : pathname}`}
+        onClick={this.closeMobileMenu}
+      >
+        {name}
+      </Link>
     )
   }
 
@@ -68,9 +75,7 @@ export default class Navigation extends Component {
         offset={-64}
       >
         {NAV_ITEMS.map(navItem => (
-          <NavItem key={navItem.name} onClick={this.closeMobileMenu}>
-            {this.getNavLink(navItem)}
-          </NavItem>
+          <NavItem key={navItem.name}>{this.getNavLink(navItem)}</NavItem>
         ))}
       </Scrollspy>
     </NavListWrapper>

--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -52,6 +52,7 @@ export default class Navigation extends Component {
   }
 
   getNavLink = ({ name, pathname, hash }) => {
+    if (typeof window === "undefined") return null
     return window.location.pathname === pathname && hash ? (
       <AnchorLink href={hash} onClick={this.closeMobileMenu}>
         {name}

--- a/src/components/sections/conferences.js
+++ b/src/components/sections/conferences.js
@@ -40,7 +40,7 @@ const Mission = () => (
 
       <MissionGrid>
         {conferences.map(conference => (
-          <FeatureItem>
+          <FeatureItem key={conference.name}>
             <FeatureTitle>
               {conference.name} {conference.free && <FreeLabel>FREE</FreeLabel>}
             </FeatureTitle>


### PR DESCRIPTION
# Description

- Adds "opportunities" link to nav-list.
- Makes nav-links more flexible so they work on pages other than the home page.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes https://github.com/M0nica/ambition-fund-website/issues/11


## Pages/Interfaces that will change
Navigation

### Screenshots of Changes

![made-links-work](https://user-images.githubusercontent.com/42680433/85233960-2ccd5100-b3bf-11ea-8d00-ef41833d53f2.gif)

## Steps to test
<!-- What steps should someone walk through to test this improvement? -->
1. Go to http://localhost:8000/ and click on the "opportunities" link. Should navigate to the opportunities page.
2. Click the "mission" link. This should navigate to the home page, scrolled to the "mission" section.
3. While on the home page, clicking the title or the "mission" links should smooth-scroll to the correct section.